### PR TITLE
deps: fix stgfunc branch reference

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,14 @@ jobs:
                     - 65
                 python-version:
                     - "3.11"
+        defaults:
+            run:
+                shell: bash
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -27,5 +30,4 @@ jobs:
             - name: Running flake8
               run: flake8 lvsfunc
             - name: Running mypy
-              if: steps.dependencies.outcome == 'success'
               run: mypy lvsfunc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ vsexprtools>=1.4.6
 vskernels>=2.4.1
 vsmasktools>=1.1.2
 vsrgtools>=1.5.1
-stgfunc @ git+https://github.com/Jaded-Encoding-Thaumaturgy/stgfunc.git@main
+stgfunc @ git+https://github.com/Jaded-Encoding-Thaumaturgy/stgfunc.git@master


### PR DESCRIPTION
stgfunc's default branch is `master`, not `main`.

This should have been caught by CI, and sure enough there is an error there:

    Collecting stgfunc@ git+https://github.com/Jaded-Encoding-Thaumaturgy/stgfunc.git@main (from -r requirements.txt (line 10))
      Cloning https://github.com/Jaded-Encoding-Thaumaturgy/stgfunc.git (to revision main) to c:\users\runneradmin\appdata\local\temp\pip-install-gfqtr21d\stgfunc_40b67a68613b40cf9ab977f3f2ccaada
      Running command git clone --filter=blob:none --quiet https://github.com/Jaded-Encoding-Thaumaturgy/stgfunc.git 'C:\Users\runneradmin\AppData\Local\Temp\pip-install-gfqtr21d\stgfunc_40b67a68613b40cf9ab977f3f2ccaada'
      WARNING: Did not find branch or tag 'main', assuming revision or ref.
      Running command git checkout -q main
      error: pathspec 'main' did not match any file(s) known to git
      error: subprocess-exited-with-error

But looks like this wasn't causing the step to fail. From a Stack Overflow post (<https://stackoverflow.com/a/75835600>) it looks like on Windows agents we gotta set the default shell to bash in order to fail on errors in multi-line run steps like the dependencies one. So I included that change here to hopefully catch stuff like this in the future.

Also updated third-party Actions while I was at it and removed the conditional on the mypy step so that it actually runs (again the conditional was referencing a step id that didn't exist plus it looked superfluous).