### PR TITLE
feat: Add get_diff_full

### DIFF
--- a/lvsfunc/diff/func.py
+++ b/lvsfunc/diff/func.py
@@ -281,6 +281,41 @@ class FindDiff:
 
         return out_diff.std.SetFrameProps(Name=f"diff clip ({new_names})", fd_diffRanges=str(self.diff_ranges))
 
+    def get_diff_full(
+        self: FindDiff,
+        src: vs.VideoNode,
+        ref: vs.VideoNode,
+        frames_post_process: Callable[[Iterable[int]], Iterable[int]]
+        | None = remove_isolated_frames,
+    ) -> tuple[vs.VideoNode, vs.VideoNode, vs.VideoNode]:
+        """
+        Get a processed clips of the src, ref and a diff of the two.
+
+        If you haven't run `find_diff` yet, the method will do so automatically.
+
+        :param src:                     The source clip to compare.
+        :param ref:                     The reference clip to compare.
+        :param frames_post_process:     The post-processing function to use on the list of frames that are different.
+                                        Default: remove_isolated_frames (removes frames with no adjacent frames).
+
+        :return:                        A tuple containing the src, ref and diff of the two limited to the differences.
+
+        :raise CustomStopIteration:     If no differences are found.
+        """
+
+        self.find_diff(src, ref, frames_post_process=frames_post_process)
+
+        assert self._processed_clip is not None
+
+        diff_clip = core.std.MakeDiff(src, ref).text.FrameNum(9)
+
+        src_diff = self.get_clip_frames(src)
+        ref_diff = self.get_clip_frames(ref)
+
+        diff_clip = self.get_clip_frames(diff_clip).text.FrameNum(alignment=7)
+
+        return (src_diff, ref_diff, diff_clip)
+
     def get_clip_frames(
         self,
         clip: vs.VideoNode,

--- a/lvsfunc/diff/func.py
+++ b/lvsfunc/diff/func.py
@@ -192,7 +192,7 @@ class FindDiff:
         self._diff_frames = None
         self.diff_ranges = []
 
-        self._validate_inputs(src, ref)
+        src, ref = self._validate_inputs(src, ref)
         self._process(src, ref, frames_post_process)
 
         if error_on_no_diff and self._diff_frames is None:

--- a/lvsfunc/diff/func.py
+++ b/lvsfunc/diff/func.py
@@ -230,7 +230,7 @@ class FindDiff:
         :raise CustomValueError:        If `names` is not a tuple of two strings.
         """
 
-        self.find_diff(src, ref)
+        self.find_diff(src, ref, frames_post_process=frames_post_process)
 
         if not isinstance(names, tuple):
             names = (None, None)


### PR DESCRIPTION
Adds a new method to return 3 clips first clips of the src and ref of only the difference frames, and a clip of the a MakeDiff of the two with the frame numbers relative and absolute.

Also fixes a few bugs I noticed whilst using it. Mainly, the call of _validate_inputs being ignored, and frames_post_process not being passed correctly.